### PR TITLE
공통 - RQ-0001, 0002

### DIFF
--- a/src/main/java/com/ll/jigumiyak/security/DefaultSuccessHandler.java
+++ b/src/main/java/com/ll/jigumiyak/security/DefaultSuccessHandler.java
@@ -5,19 +5,25 @@ import com.ll.jigumiyak.user.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class DefaultSuccessHandler implements AuthenticationSuccessHandler {
 
     private final UserRepository userRepository;
+    private final RequestCache requestCache = new HttpSessionRequestCache();
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -33,9 +39,16 @@ public class DefaultSuccessHandler implements AuthenticationSuccessHandler {
 
         // refererUri check
         String refererUri = (String) request.getSession().getAttribute("refererUri");
+        log.info(refererUri);
         request.getSession().removeAttribute("refererUri");
 
-        if (refererUri != null) {
+        SavedRequest savedRequest = this.requestCache.getRequest(request, response);
+        String redirectUri = savedRequest != null ? savedRequest.getRedirectUrl() : null;
+        log.info(redirectUri);
+
+        if (redirectUri != null) {
+            response.sendRedirect(redirectUri);
+        } else if (refererUri != null) {
             response.sendRedirect(refererUri);
         } else {
             response.sendRedirect("/");

--- a/src/main/java/com/ll/jigumiyak/user/UserController.java
+++ b/src/main/java/com/ll/jigumiyak/user/UserController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindException;
@@ -30,6 +31,7 @@ public class UserController {
     private final UserService userService;
     private final AddressService addressService;
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/mypage")
     public String my() {
         return "mypage";
@@ -40,7 +42,8 @@ public class UserController {
                         @RequestParam(value = "error", defaultValue = "") String error,
                         @RequestParam(value = "field", defaultValue = "") String field) {
 
-        String refererUri = request.getHeader("referer");
+        String refererUri = request.getHeader("Referer");
+        log.info(request.toString());
         log.info(refererUri);
 
         if (refererUri != null && !refererUri.contains("/user/login") && !refererUri.contains("/user/signup")) {

--- a/src/main/java/com/ll/jigumiyak/user/UserController.java
+++ b/src/main/java/com/ll/jigumiyak/user/UserController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,13 +78,14 @@ public class UserController {
         log.info("address.subAddress: " + userSignupForm.getAddress().getSubAddress());
 
         if (bindingResult.hasErrors()) {
+            List<String> errorList = new ArrayList<>();
             for (FieldError fieldError : bindingResult.getFieldErrors()) {
-                log.info(fieldError.toString());
                 log.info("field: " + fieldError.getField());
                 log.info("code: " + fieldError.getCode());
                 log.info("message: " + fieldError.getDefaultMessage());
+                errorList.add(fieldError.getField() + ": " + fieldError.getDefaultMessage());
             }
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(bindingResult.getFieldErrors());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorList);
         }
 
         if (this.userService.isDuplicatedId(userSignupForm.getLoginId())) {
@@ -106,7 +108,16 @@ public class UserController {
             bindingResult.rejectValue("address", "NotEmpty", "주소는 필수 항목입니다.");
         }
 
-        if (bindingResult.hasErrors()) return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(bindingResult.getFieldErrors());
+        if (bindingResult.hasErrors()) {
+            List<String> errorList = new ArrayList<>();
+            for (FieldError fieldError : bindingResult.getFieldErrors()) {
+                log.info("field: " + fieldError.getField());
+                log.info("code: " + fieldError.getCode());
+                log.info("message: " + fieldError.getDefaultMessage());
+                errorList.add(fieldError.getField() + ": " + fieldError.getDefaultMessage());
+            }
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorList);
+        }
 
         Address address = this.addressService.create(userSignupForm.getAddress().getZoneCode(),
                 userSignupForm.getAddress().getMainAddress(),

--- a/src/main/resources/static/signup.js
+++ b/src/main/resources/static/signup.js
@@ -71,16 +71,20 @@ function _signup() {
         type: "POST",
         data: $("#userSignupForm").serialize(),
         beforeSend : function() {
-          var token = $("meta[name='_csrf']").attr("content");
-          var header = $("meta[name='_csrf_header']").attr("content");
-          $(document).ajaxSend(function(e, xhr, options) { xhr.setRequestHeader(header, token); });
+            var token = $("meta[name='_csrf']").attr("content");
+            var header = $("meta[name='_csrf_header']").attr("content");
+            $(document).ajaxSend(function(e, xhr, options) { xhr.setRequestHeader(header, token); });
         },
         success: function(data) {
-          alert(data);
-          location.href = "/user/login";
+            alert(data);
+            location.href = "/user/login";
         },
         error: function(res) {
-          alert("입력을 전부 완료해주세요");
+            let errorMsg = "";
+            $.each(res.responseJSON, function(key, value){
+                errorMsg += value + "\n";
+            });
+            alert(errorMsg);
         }
     })
 }

--- a/src/main/resources/templates/navbar.html
+++ b/src/main/resources/templates/navbar.html
@@ -18,7 +18,7 @@
                     </a>
                 </li>
                 <li class="menu-1__li-icon">
-                    <a class="h-full flex items-center px-2 cursor-pointer" th:attr="onclick=|_anonymous('/user/mypage', '${#authentication.details.sessionId != null}')|">
+                    <a class="h-full flex items-center px-2 cursor-pointer" th:attr="onclick=|_anonymous('/user/mypage', '${!#strings.contains(#authentication.authorities, 'ROLE_ANONYMOUS')}')|">
                         <span><i class="far fa-user"></i></span>
                     </a>
                 </li>


### PR DESCRIPTION
**RQ-0001**
 로그인하지 않은 사용자가 로그인이 필요한 페이지로 이동하는 버튼 클릭 시 “로그인이 필요한 서비스입니다. 확인을 누르시면 로그인 페이지로 이동합니다.” 라는 confirm 알림이 표시된다.

**RQ-0002**
 confirm 알림 창에서 확인 버튼 클릭 시 로그인 페이지로 이동하고, 로그인이 정상적으로 완료되면 이동하려던 페이지로 이동한다.

### 로그인이 필요한 컨트롤러에 요청 보낼 때 처리하는 로직 코드 수정
- 예시 코드
`<tag th:attr="onclick=|_anonymous('/user/login', '${!#strings.contains(#authentication.authorities, 'ROLE_ANONYMOUS')}')|"></tag>`
- 페이지 이동 발생 시 ==> /user/login 을 이동할 페이지로 교체
- 해당 기능 이용 시 아래 코드 템플릿에 삽입 필수
`<script type="text/javascript" th:inline="javascript" th:src="@{/common.js}"></script>`

### 회원가입 페이지 임시 반영 사항
- binding error 발생 시 상단 알림창에 에러 출력

확인 후 리뷰 부탁드립니다.